### PR TITLE
Añade ñapa para reconocer comando

### DIFF
--- a/api/kke_agilgrx.go
+++ b/api/kke_agilgrx.go
@@ -91,7 +91,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(body,&update); err != nil {
 		log.Fatal("Error en el update →", err)
 	}
-	if update.Message != nil &&  update.Message.IsCommand() {
+	if update.Message != nil &&  update.Message.IsCommand() && update.Message.Command() == "kke" {
 		log.Printf("[%s] %s", update.Message.From.UserName, update.Message.Text)
 		text := ""
 		argument := update.Message.CommandArguments()


### PR DESCRIPTION
Este commit añade una condición para que el bot solo actúe cuando el comando capturado sea "kke". Hecho esto, podría eliminarse el switch de la línea 104 a costa de perder la respuesta informativa de la línea 117.